### PR TITLE
[OI] update execute_command in ubuntu-base-amd64-ebs template

### DIFF
--- a/templates/ubuntu-base-amd64-ebs.json
+++ b/templates/ubuntu-base-amd64-ebs.json
@@ -51,7 +51,7 @@
   "provisioners": [
     {
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "execute_command": "{{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
@@ -75,7 +75,7 @@
     },
     {
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "execute_command": "{{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"


### PR DESCRIPTION
Remove `vagrant` password passed to sudo command, which is unnecessary
as `ubuntu` user is passwordless.